### PR TITLE
Do not release zalgo

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,10 +13,14 @@ var thunky = function(fn) {
 		fn(function(err) {
 			var args = arguments;
 			var apply = function(callback) {
+				if (callback) callback.apply(null, args);
+			};
+
+			var applyNextTick = function(callback) {
 				if (callback) process.nextTick(function () { callback.apply(null, args); });
 			};
 
-			state = isError(err) ? run : apply;
+			state = isError(err) ? run : applyNextTick;
 			while (stack.length) apply(stack.shift());
 		});
 	};

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var thunky = function(fn) {
 		fn(function(err) {
 			var args = arguments;
 			var apply = function(callback) {
-				if (callback) callback.apply(null, args);
+				if (callback) process.nextTick(function () { callback.apply(null, args); });
 			};
 
 			state = isError(err) ? run : apply;


### PR DESCRIPTION
Once the result of a thunky function is cached, future calls return the
result immediately. This PR adds a process.nextTick() so the result is
always async.

Background on zalgo:
http://blog.izs.me/post/59142742143/designing-apis-for-asynchrony
