### PR TITLE
Support promises and async/await

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,30 @@ fails(function (err) { // inner function is called again as it returned an error
 })
 ```
 
+## Promises
+
+* The worker function passed to thunky can return a promise instead of accepting a `done` callback. The promise will be run
+  and awaited once.
+* The returned thunk can be awaited instead of being accessed via a callback.
+
+```js
+  // These are equal:
+  const ready = thunky(function (done) {
+    someAsyncFunction().then(done)
+  }
+  const ready = thunky(async () {
+    return someAsyncFunction()
+  }
+
+  // These are also equal:
+  ready(() => console.log('ready!'))
+  ready().then(() => console.log('ready!')
+
+  // or in an async function
+  await ready()
+  console.log('ready!')
+```
+
 ## License
 
 MIT

--- a/test.js
+++ b/test.js
@@ -120,3 +120,30 @@ tape('always async', function (t) {
   })
   sync = false
 })
+
+tape('await a thunk', async function (t) {
+  let ran = 0
+  const ready = thunky(done => process.nextTick(() => {
+    ran++
+    done()
+  }))
+  await ready()
+  t.same(ran, 1)
+  await ready()
+  t.same(ran, 1)
+  t.end()
+})
+
+tape('promise inside', async function (t) {
+  let ran = 0
+  const ready = thunky(async () => {
+    ran++
+  })
+  ready(() => {
+    t.same(ran, 1)
+    ready().then(() => {
+      t.same(ran, 1)
+      t.end()
+    })
+  })
+})

--- a/test.js
+++ b/test.js
@@ -134,16 +134,26 @@ tape('await a thunk', async function (t) {
   t.end()
 })
 
-tape('promise inside', async function (t) {
+tape('await a promise', async function (t) {
+  t.plan(2)
   let ran = 0
+  let done
+  let promise = new Promise((resolve, reject) => {
+    done = () => resolve()
+  })
+
   const ready = thunky(async () => {
+    await promise
     ran++
   })
+
   ready(() => {
     t.same(ran, 1)
-    ready().then(() => {
-      t.same(ran, 1)
-      t.end()
-    })
+  })
+
+  done()
+
+  ready(() => {
+    t.same(ran, 1)
   })
 })


### PR DESCRIPTION
I've seen myself working in async functions more often, and being able to await a thunk makes things simpler. I then realized that this can be added even in a backwards compatible way with minimal changes.

Thus, this PR adds support for promises in both areas without breaking any callback workflow:

* The worker function can return a promise instead of invoking `done`.
* The thunk function returns a promise if not passed a callback that can be awaited.

I was thinking of doing a new module async-thunky or something, but as the change does not break anything I think it'd be best to just do it in here.